### PR TITLE
Only pull forbiddenfruit if impl is cpython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blockbuster"
-version = "1.5.23"
+version = "1.5.24"
 description = "Utility to detect blocking calls in the async event loop"
 readme = "README.md"
 keywords = ["async", "block", "detect", "event loop", "asyncio"]
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "forbiddenfruit>=0.1.4",
+    "forbiddenfruit>=0.1.4; implementation_name== 'cpython'",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -16,10 +16,10 @@ wheels = [
 
 [[package]]
 name = "blockbuster"
-version = "1.5.23"
+version = "1.5.24"
 source = { editable = "." }
 dependencies = [
-    { name = "forbiddenfruit" },
+    { name = "forbiddenfruit", marker = "implementation_name == 'cpython'" },
 ]
 
 [package.dev-dependencies]
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "forbiddenfruit", specifier = ">=0.1.4" }]
+requires-dist = [{ name = "forbiddenfruit", marker = "implementation_name == 'cpython'", specifier = ">=0.1.4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change updates the dependency specification for `forbiddenfruit` to be conditional based on the implementation name being 'cpython'.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L12-R12): Updated the dependency `forbiddenfruit` to be conditional on the implementation name being 'cpython'.