### PR TITLE
Add `ThreadPoolExecutor.submit` to ignored methods

### DIFF
--- a/blockbuster/blockbuster.py
+++ b/blockbuster/blockbuster.py
@@ -586,7 +586,7 @@ def _get_lock_wrapped_functions(
             "acquire",
             can_block_predicate=lock_acquire_exclude,
             can_block_functions=[
-                ("threading.py", {"start"}),
+                ("threading.py", {"start", "_acquire_restore"}),
                 ("/pydevd.py", {"_do_wait_suspend"}),
                 ("asyncio/base_events.py", {"shutdown_default_executor"}),
             ],
@@ -597,7 +597,7 @@ def _get_lock_wrapped_functions(
             _thread.LockType,
             "acquire_lock",
             can_block_predicate=lock_acquire_exclude,
-            can_block_functions=[("threading.py", {"start"})],
+            can_block_functions=[("threading.py", {"start", "_acquire_restore"})],
             scanned_modules=modules,
             excluded_modules=excluded_modules,
         ),

--- a/blockbuster/blockbuster.py
+++ b/blockbuster/blockbuster.py
@@ -586,9 +586,10 @@ def _get_lock_wrapped_functions(
             "acquire",
             can_block_predicate=lock_acquire_exclude,
             can_block_functions=[
-                ("threading.py", {"start", "_acquire_restore"}),
+                ("threading.py", {"start"}),
                 ("/pydevd.py", {"_do_wait_suspend"}),
                 ("asyncio/base_events.py", {"shutdown_default_executor"}),
+                ("concurrent/futures/thread.py", {"submit"}),
             ],
             scanned_modules=modules,
             excluded_modules=excluded_modules,
@@ -597,7 +598,10 @@ def _get_lock_wrapped_functions(
             _thread.LockType,
             "acquire_lock",
             can_block_predicate=lock_acquire_exclude,
-            can_block_functions=[("threading.py", {"start", "_acquire_restore"})],
+            can_block_functions=[
+                ("threading.py", {"start"}),
+                ("concurrent/futures/thread.py", {"submit"}),
+            ],
             scanned_modules=modules,
             excluded_modules=excluded_modules,
         ),


### PR DESCRIPTION
This is an internal function used during cleanup, and we can't really do anything about it. Even when correctly using the Python library (e.g. acquiring the semaphore with timeout=0), in some rare cases the something to avoid this call.

Fixes: #52 