### PR TITLE
Add test that `blockbuster_skip` is task-local

### DIFF
--- a/tests/test_blockbuster.py
+++ b/tests/test_blockbuster.py
@@ -215,29 +215,6 @@ async def test_custom_stack_exclude(blockbuster: BlockBuster, test_file: Path) -
     allowed_read(test_file)
 
 
-async def test_blockbuster_skip_is_task_local() -> None:
-    skipped_task_ready = asyncio.Event()
-    blocked_task_done = asyncio.Event()
-
-    async def skip_blockbuster() -> None:
-        token = blockbuster_skip.set(True)
-        try:
-            skipped_task_ready.set()
-            await blocked_task_done.wait()
-            time.sleep(0)  # noqa: ASYNC251
-        finally:
-            blockbuster_skip.reset(token)
-
-    async def expect_blocking_error() -> None:
-        await skipped_task_ready.wait()
-        with pytest.raises(BlockingError, match=r"Blocking call to time.sleep"):
-            time.sleep(0)  # noqa: ASYNC251
-        blocked_task_done.set()
-
-    await asyncio.gather(skip_blockbuster(), expect_blocking_error())
-    assert blockbuster_skip.get(False) is False
-
-
 async def test_cleanup(blockbuster: BlockBuster, test_file: Path) -> None:
     blockbuster.deactivate()
     with test_file.open(mode="wb") as f:
@@ -484,3 +461,26 @@ def test_can_block_in_builder(blockbuster: BlockBuster) -> None:
     )
     assert ("foo.py", {"bar"}) in blockbuster.functions["os.stat"].can_block_functions
     assert ("baz.py", {"qux"}) in blockbuster.functions["os.stat"].can_block_functions
+
+
+async def test_blockbuster_skip_is_task_local() -> None:
+    skipped_task_ready = asyncio.Event()
+    blocked_task_done = asyncio.Event()
+
+    async def skip_blockbuster() -> None:
+        token = blockbuster_skip.set(True)
+        try:
+            skipped_task_ready.set()
+            await blocked_task_done.wait()
+            time.sleep(0)  # noqa: ASYNC251
+        finally:
+            blockbuster_skip.reset(token)
+
+    async def expect_blocking_error() -> None:
+        await skipped_task_ready.wait()
+        with pytest.raises(BlockingError, match=r"Blocking call to time.sleep"):
+            time.sleep(0)  # noqa: ASYNC251
+        blocked_task_done.set()
+
+    await asyncio.gather(skip_blockbuster(), expect_blocking_error())
+    assert blockbuster_skip.get(False) is False

--- a/tests/test_blockbuster.py
+++ b/tests/test_blockbuster.py
@@ -21,6 +21,7 @@ import requests
 
 import tests
 from blockbuster import BlockBuster, BlockingError, blockbuster_ctx
+from blockbuster.blockbuster import blockbuster_skip
 from tests import subpackage
 
 _T = TypeVar("_T")
@@ -212,6 +213,29 @@ async def test_custom_stack_exclude(blockbuster: BlockBuster, test_file: Path) -
         )
     )
     allowed_read(test_file)
+
+
+async def test_blockbuster_skip_is_task_local() -> None:
+    skipped_task_ready = asyncio.Event()
+    blocked_task_done = asyncio.Event()
+
+    async def skip_blockbuster() -> None:
+        token = blockbuster_skip.set(True)
+        try:
+            skipped_task_ready.set()
+            await blocked_task_done.wait()
+            time.sleep(0)  # noqa: ASYNC251
+        finally:
+            blockbuster_skip.reset(token)
+
+    async def expect_blocking_error() -> None:
+        await skipped_task_ready.wait()
+        with pytest.raises(BlockingError, match=r"Blocking call to time.sleep"):
+            time.sleep(0)  # noqa: ASYNC251
+        blocked_task_done.set()
+
+    await asyncio.gather(skip_blockbuster(), expect_blocking_error())
+    assert blockbuster_skip.get(False) is False
 
 
 async def test_cleanup(blockbuster: BlockBuster, test_file: Path) -> None:


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Split out of #61 at the maintainer's request — it is a coverage addition, not part of that PR's perf work.

`blockbuster_skip` is the re-entrancy guard the wrapper sets around its own frame walk. Because it is a `ContextVar` and every task gets its own context copy, one task holding the guard must not silently disable detection in a concurrent task. Nothing covered that today.

The test runs two tasks under `asyncio.gather`: one sets `blockbuster_skip` and blocks, the other asserts a `BlockingError` is still raised for `time.sleep` while the first holds the flag.
