### PR TITLE
Fix `AttributeError` on reads from file objects without a fileno

### DIFF
--- a/blockbuster/blockbuster.py
+++ b/blockbuster/blockbuster.py
@@ -457,10 +457,12 @@ def _get_io_wrapped_functions(
         except io.UnsupportedOperation:
             return not file.isatty()
         except AttributeError:
-            # A `tarfile.ExFileObject` is an `io.BufferedReader` over a raw
-            # object implementing neither `fileno` nor `isatty`. It reads through
-            # to the enclosing archive, so it blocks and must not escape as an
-            # `AttributeError`.
+            # The wrapped raw object implements neither `fileno` nor `isatty`,
+            # so nothing is left to prove the read won't hit the disk: treat any
+            # file reaching this branch as blocking. That is correct for a
+            # `tarfile.ExFileObject`, which reads through to the enclosing
+            # archive, and is the deliberate default for any other file type
+            # that lands here.
             pass
         return False
 

--- a/blockbuster/blockbuster.py
+++ b/blockbuster/blockbuster.py
@@ -456,6 +456,12 @@ def _get_io_wrapped_functions(
             file.fileno()
         except io.UnsupportedOperation:
             return not file.isatty()
+        except AttributeError:
+            # A `tarfile.ExFileObject` is an `io.BufferedReader` over a raw
+            # object implementing neither `fileno` nor `isatty`. It reads through
+            # to the enclosing archive, so it blocks and must not escape as an
+            # `AttributeError`.
+            pass
         return False
 
     def file_write_exclude(file: io.IOBase, *_: Any, **__: Any) -> bool:

--- a/tests/test_blockbuster.py
+++ b/tests/test_blockbuster.py
@@ -9,6 +9,7 @@ import platform
 import socket
 import sqlite3
 import sys
+import tarfile
 import tempfile
 import threading
 import time
@@ -141,6 +142,27 @@ async def test_file_read_bytes(test_file: Path) -> None:
         assert isinstance(f, io.BufferedReader)
         with pytest.raises(BlockingError, match=r"io.BufferedReader.read"):
             f.read(1)
+
+
+@pytest.fixture
+def tar_member() -> Iterator[io.BufferedReader]:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        member = Path(tmp_dir) / "member.txt"
+        member.write_bytes(b"foo")
+        tar_path = Path(tmp_dir) / "archive.tar"
+        with tarfile.open(tar_path, mode="w") as tar:
+            tar.add(member, arcname=member.name)
+        with tarfile.open(tar_path) as tar:
+            fileobj = tar.extractfile(member.name)
+            assert isinstance(fileobj, io.BufferedReader)
+            yield fileobj
+
+
+async def test_tar_member_read(tar_member: io.BufferedReader) -> None:
+    # The raw object behind a `tarfile.ExFileObject` implements neither `fileno`
+    # nor `isatty`, but the read goes through to the archive file.
+    with pytest.raises(BlockingError, match=r"Blocking call to io.BufferedReader.read"):
+        tar_member.read(1)
 
 
 async def test_file_write_bytes(test_file: Path) -> None:


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.
>
> David decided the approach and has not reviewed the implementation.

`file_read_exclude` calls `file.fileno()` and catches only `io.UnsupportedOperation`. A `tarfile.ExFileObject` is an `io.BufferedReader` over a `tarfile._FileInFile`, which implements neither `fileno` nor `isatty`, so the predicate raises `AttributeError` into the caller.

`can_block_predicate` runs before the stack walk in `_wrap_blocking`, so the error escapes whatever the observed code was doing regardless of `scanned_modules` — a detector meant to observe blocking I/O changes the outcome of the code it observes.

```python
import asyncio, tarfile
from blockbuster import BlockBuster

async def main():
    BlockBuster().activate()
    with tarfile.open("archive.tar") as tar:
        tar.extractfile("member.txt").read()
        # AttributeError: '_FileInFile' object has no attribute 'fileno'

asyncio.run(main())
```

Catching `AttributeError` alone isn't enough: the `io.UnsupportedOperation` branch recovers with `file.isatty()`, which raises the same error on the same object. Falling through to `return False` avoids that.

### The stance this takes

This reports such a read as **blocking** rather than allowing it. A `True` return means "may block, let it through", and a tar member read goes through to the enclosing archive file, so allowing it would be a false negative. It also makes one real-world case report consistently: `dateutil.tz` reads a plain `TZif` file where the system has one, and its bundled `dateutil-zoneinfo.tar.gz` where it doesn't. The first is already reported today; with this change the second is too, instead of raising.

So this is a deliberate behaviour change for file objects that have no `fileno` and aren't in-memory streams: they now raise `BlockingError` instead of `AttributeError`. If you'd rather group them with `io.BytesIO` and allow them, that's a one-line change to the same branch — happy to switch.

### Not changed: `file_write_exclude`

It has the identical unguarded shape — `file.isatty()` on the first line, before the `fileno` probe — and would raise the same `AttributeError`. I couldn't construct a case that reaches it, so I left it rather than guard it on a hunch.

<details><summary>What I checked</summary>

Every stdlib writer that lands on a patched class has a working `isatty`: `gzip.open(..., "wt")`, `socket.makefile("w")` and `("wb")`, a `subprocess` stdin pipe, `tarfile`'s own output `fileobj`, `io.TextIOWrapper(io.BytesIO())`. The `bz2`, `lzma` and `zipfile` writers aren't `BufferedWriter` / `BufferedRandom` / `TextIOWrapper` at all, so they're never wrapped. Only a synthetic duck-typed raw object reproduces it.

Tar members are read-only, so the class that triggers this on the read side may simply have no write analogue. Say the word if you want it guarded anyway.
</details>

<details><summary>How this surfaced</summary>

An `import pandas` inside a running loop reaches `dateutil.tz`, which on a machine without a matching system zoneinfo entry reads its bundled tarball. The `AttributeError` aborts the import and leaves a partially initialized `pandas` in `sys.modules`, so every later `import pandas` in the process fails with an unrelated-looking `_pandas_datetime_CAPI` error and the original cause is nowhere in the traceback.

Downstream report: https://github.com/pydantic/pydantic-ai/issues/7446
</details>

### Tests

`test_tar_member_read` builds and opens the archive in a sync fixture — the detector would flag that setup otherwise, same as the existing `test_file` fixture — and asserts the member read raises `BlockingError`. Verified failing without the production change (`AttributeError: '_FileInFile' object has no attribute 'fileno'`) and passing with it.

`tests/test_blockbuster.py` 65 passed; `ruff check`, `ruff format --check` and `mypy blockbuster tests` clean.
