### PR TITLE
Fix compatibility with Python 3.15

### DIFF
--- a/blockbuster/blockbuster.py
+++ b/blockbuster/blockbuster.py
@@ -371,7 +371,9 @@ def _get_os_wrapped_functions(
         excluded_modules=excluded_modules,
     )
 
-    if platform.python_implementation() != "CPython" or sys.version_info >= (3, 9):
+    if platform.python_implementation() != "CPython" or (
+        (3, 9) <= sys.version_info < (3, 15)
+    ):
         with os.scandir() as scandir_it:
             functions["os.scandir"] = BlockBusterFunction(
                 type(scandir_it),
@@ -379,6 +381,13 @@ def _get_os_wrapped_functions(
                 scanned_modules=modules,
                 excluded_modules=excluded_modules,
             )
+    else:
+        functions["os.scandir"] = BlockBusterFunction(
+            None,
+            "os.scandir",
+            scanned_modules=modules,
+            excluded_modules=excluded_modules,
+        )
 
     for method in (
         "ismount",

--- a/tests/test_blockbuster.py
+++ b/tests/test_blockbuster.py
@@ -469,12 +469,15 @@ async def test_os_listdir() -> None:
         os.listdir("/1")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9+")
 async def test_os_scandir() -> None:
-    with os.scandir(tempfile.tempdir) as files, pytest.raises(
-        BlockingError, match=r"Blocking call to ScandirIterator.__next__"
-    ):
-        next(files)
+    if (3, 9) <= sys.version_info < (3, 15):
+        with os.scandir(tempfile.tempdir) as files, pytest.raises(
+                               BlockingError, match="Blocking call to ScandirIterator.__next__"
+        ):
+            next(files)
+    else:
+        with pytest.raises(BlockingError, match="Blocking call to os.scandir"):
+            os.scandir(tempfile.tempdir)
 
 
 async def test_os_access() -> None:


### PR DESCRIPTION
In Python 3.15, posix.ScandirIterator has become an immutable type, causing setattr(type(scandir_it), '__next__', ...) to raise TypeError.

On Python 3.15+ (and Python < 3.9), fall back to hooking os.scandir directly on the os module instead of ScandirIterator.__next__.